### PR TITLE
Generate ssh key, validate user input, and tag clusters

### DIFF
--- a/deploy/config.py
+++ b/deploy/config.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import yaml
 
@@ -40,9 +41,19 @@ class Config:
         self.load()
 
     def set_credentials_file_path(self, file_path):
-        self.credentials.set_file_path(file_path)
-        self.config["credentials"]["path"] = file_path
-        self.save()
+        if os.path.exists(os.path.dirname(file_path)):
+            self.credentials.set_file_path(file_path)
+            self.config["credentials"]["path"] = file_path
+            self.save()
+            return [{
+                "alert-type": "alert-success",
+                "message": "Path saved"
+            }]
+        else:
+            return [{
+                "alert-type": "alert-danger",
+                "message": "Path not found"
+            }]
 
     def load(self):
         def merge_dict(tgt, src):

--- a/deploy/credentials.py
+++ b/deploy/credentials.py
@@ -1,9 +1,15 @@
+import boto.ec2
+import os
+import socket
+import time
 import yaml
+
+ec2_region = "us-east-1"
 
 
 class Credentials:
     ec2_keys = ["aws-access-key-id", "aws-secret-access-key",
-                "key-name", "identity-file"]
+                "key-name", "identity-file", "email-address", "ssh-key"]
     s3_keys = ["aws-access-key-id", "aws-secret-access-key"]
 
     def __init__(self, file_path):
@@ -24,11 +30,160 @@ class Credentials:
             self.credentials = {"ec2": {}, "s3": {}}
 
     def add(self, cred, usage):
+        add_status = []
+
         if usage == "ec2":
-            self.credentials["ec2"][cred["name"]] = \
-                {key: cred[key] for key in self.ec2_keys}
+            # Generate an ssh key pair if the option was selected
+            if cred["ssh-key"] == "generate":
+                key_name, identity_file, ssh_key_status = \
+                    self.create_ssh_key(cred["aws-access-key-id"],
+                                        cred["aws-secret-access-key"],
+                                        cred["email-address"])
+                add_status = add_status + ssh_key_status
+                # If no key was created then don't save the credentials and return immediately
+                if key_name is None or identity_file is None:
+                    return add_status
+                self.credentials["ec2"][cred["name"]] = {
+                    "aws-access-key-id": cred["aws-access-key-id"],
+                    "aws-secret-access-key": cred["aws-secret-access-key"],
+                    "key-name": key_name,
+                    "email-address": cred["email-address"],
+                    "identity-file": identity_file
+                }
+            else:
+                # Record form the values if the option to generate an ssh key pair was not selected
+                self.credentials["ec2"][cred["name"]] = \
+                    {key: cred[key] for key in self.ec2_keys}
+
+            # Test if AWS credentials are valid
+            valid, test_credentials_status = self.test_ec2_credentials(cred["name"])
+
+            # If the credentials are invalid then don't save the credentials and return immediately
+            if not valid:
+                add_status = add_status + test_credentials_status
+                return add_status
         elif usage == "s3":
             self.credentials["s3"][cred["name"]] =  \
                 {key: cred[key] for key in self.s3_keys}
         with open(self.file_path, 'w') as stream:
             stream.write(yaml.dump(self.credentials, default_flow_style=False))
+
+        add_status = add_status + [{
+            "alert-type": "alert-success",
+            "message": "AWS Account Added"
+        }]
+        return add_status
+
+    def test_ec2_credentials(self, name):
+        test_credentials_status = []
+        
+        aws_access_key_id = self.credentials["ec2"][name]["aws-access-key-id"]
+        aws_secret_access_key = self.credentials["ec2"][name]["aws-secret-access-key"]
+        
+        conn = None
+        
+        try:
+            conn = boto.ec2.connect_to_region(ec2_region,
+                                              aws_access_key_id=aws_access_key_id,
+                                              aws_secret_access_key=aws_secret_access_key)
+        except Exception, e:
+            test_credentials_status.append({
+                "alert-type": "alert-danger",
+                "message": "There was an error connecting to EC2: %s" % e
+            })
+
+        # Test the AWS Key and Secret and get all of the EC2 key pairs
+        aws_key_pairs = []
+        try:
+            aws_key_pairs = conn.get_all_key_pairs()
+        except boto.exception.EC2ResponseError, e:
+            conn.close()
+            if e.error_code == "AuthFailure":
+                test_credentials_status.append({
+                    "alert-type": "alert-danger",
+                    "message": "Invalid AWS Access Key ID or AWS Secret Access Key"
+                })
+            else:
+                test_credentials_status.append({
+                    "alert-type": "alert-danger",
+                    "message": "There was an error creating a new SSH key pair: %s" % e.error_code
+                })
+
+        # Verify the EC2 key pair name is in EC2
+        if not any(self.credentials["ec2"][name]["key-name"] in k.name for k in aws_key_pairs):
+            test_credentials_status.append({
+                "alert-type": "alert-danger",
+                "message": "Key Name not found on AWS"
+            })
+
+        # Verify the identity file exists
+        if not os.path.isfile(self.credentials["ec2"][name]["identity-file"]):
+            conn.close()
+            test_credentials_status.append({
+                "alert-type": "alert-danger",
+                "message": "Key Identity File not found"
+            })
+
+        if len(test_credentials_status) > 0:
+            return False, test_credentials_status
+        else:
+            return True, test_credentials_status
+
+    def create_ssh_key(self, aws_access_key_id, aws_secret_access_key, email_address):
+        ssh_key_status = []
+
+        try:
+            conn = boto.ec2.connect_to_region(ec2_region,
+                                              aws_access_key_id=aws_access_key_id,
+                                              aws_secret_access_key=aws_secret_access_key)
+        except Exception, e:
+            ssh_key_status.append({
+                "alert-type": "alert-danger",
+                "message": "There was an error connecting to EC2: %s" % e
+            })
+            return None, None, ssh_key_status
+
+        ec2_ssh_key_name = "%s_%s_%s" % (str(email_address.split("@")[0]),
+                                         str(socket.gethostname()),
+                                         str(int(time.time())))
+
+        # Create an EC2 key pair
+        try:
+            key = conn.create_key_pair(key_name=ec2_ssh_key_name)
+            key.save(os.path.dirname(os.path.abspath(self.file_path)))
+        except boto.exception.EC2ResponseError, e:
+            conn.close()
+            if e.error_code == "AuthFailure":
+                ssh_key_status.append({
+                    "alert-type": "alert-danger",
+                    "message": "Invalid AWS Access Key ID or AWS Secret Access Key"
+                })
+            else:
+                ssh_key_status.append({
+                    "alert-type": "alert-danger",
+                    "message": "There was an error creating a new SSH key pair: %s" % e.error_code
+                })
+            return None, None, ssh_key_status
+        except Exception, e:
+            conn.close()
+            ssh_key_status.append({
+                "alert-type": "alert-danger",
+                "message": "Unknown Error: %s" % e
+            })
+            return None, None, ssh_key_status
+
+        ec2_ssh_key_pair_file = os.path.dirname(os.path.abspath(self.file_path)) + \
+            "/" + ec2_ssh_key_name + ".pem"
+
+        # Verify the key pair was saved locally
+        if not os.path.isfile(ec2_ssh_key_pair_file):
+            conn.close()
+            ssh_key_status.append({
+                "alert-type": "alert-danger",
+                "message": "SSH key not saved"
+            })
+            return None, None, ssh_key_status
+
+        conn.close()
+
+        return ec2_ssh_key_name, ec2_ssh_key_pair_file, ssh_key_status

--- a/deploy/server.py
+++ b/deploy/server.py
@@ -64,25 +64,27 @@ def launch_new_cluster():
 
 @app.route('/', methods=['GET', 'POST'])
 def select_aws():
+    credentials_status = []
     '''Show all available AWS accounts.'''
     if request.method == "POST":
         # Set a new config file path
         if request.form["type"] == "set-path":
-            config.set_credentials_file_path(str(request.form["path"]))
+            credentials_status = config.set_credentials_file_path(str(request.form["path"]))
         # Add a new AWS account
         elif request.form["type"] == "add-account":
             data = {key: str(request.form[key])
                     for key in config.credentials.ec2_keys}
             data['name'] = str(request.form['name'])
             data['identity-file'] = os.path.expanduser(data['identity-file'])
-            config.credentials.add(data, 'ec2')
+            credentials_status = config.credentials.add(data, 'ec2')
         # Invalid parameter
         else:
             pass
 
     return render_template('accounts.html',
                            clusters=config.credentials.credentials,
-                           cred_path=config.credentials.file_path)
+                           cred_path=config.credentials.file_path,
+                           credentials_status=credentials_status)
 
 
 @app.route('/account/<account>', methods=['GET', 'POST'])

--- a/deploy/spark_helper.py
+++ b/deploy/spark_helper.py
@@ -110,6 +110,8 @@ class SparkHelper:
                 "--zone=" + self.config['ec2']['zone'],
                 "--slaves=%d" % int(self.workers),
                 "--instance-type=" + self.instance,
+                "--additional-tags=cluster:%s,email:%s" %
+                (self.email_address.split("@")[0], self.email_address),
                 "--hadoop-major-version=yarn",
                 "--use-existing-master"]
         if self.spot_price:
@@ -246,6 +248,7 @@ class SparkHelper:
             cred["ec2"][account]["key-name"],
             cred["ec2"][account]["identity-file"]
         )
+        self.email_address = cred["ec2"][account]["email-address"]
         self.conn = boto.ec2.connect_to_region(
             self.config['ec2']['region'],
             aws_access_key_id=self.AWS_ACCESS_KEY_ID,

--- a/deploy/templates/accounts.html
+++ b/deploy/templates/accounts.html
@@ -6,6 +6,14 @@
 
 <hr>
 
+{% if credentials_status != None %}
+    {% for status in credentials_status %}
+    <div class="alert {{ status["alert-type"] }}">
+        {{ status["message"] }}
+    </div>
+    {% endfor %}
+{% endif %}
+
 <div class="row-fluid">
     <div class="span12">
         <h4>Change AWS credential file location</h4>

--- a/deploy/templates/accounts.html
+++ b/deploy/templates/accounts.html
@@ -25,7 +25,7 @@
                    placeholder="{{"Current path: " + cred_path}}"
                    required>
             <button type="submit" class="btn btn-primary btn-form">
-                Set file path
+                Set path
             </button>
         </form>
 
@@ -51,9 +51,14 @@
         <h4>Add a new AWS account</h4>
         <form class="form-add-account" action="" method="POST">
             <input type="hidden" name="type" value="add-account"/>
-            <label>Display name</label>
+            <label>Display Name</label>
             <input id="name" name="name" class="form-control"
                    placeholder="A name that will show in the dropdown menu above"
+                   required>
+
+            <label>Your Email Address</label>
+            <input id="name" name="email-address" class="form-control"
+                   placeholder="Enter your @eng.ucsd.edu email address"
                    required>
 
             <label>AWS Access Key ID</label>
@@ -64,15 +69,49 @@
             <input id="aws-secret-access-key" class="form-control"
                    name="aws-secret-access-key" required>
 
-            <label>Key Name</label>
-            <input id="key-name" class="form-control" name="key-name" required>
+            <br/>
+            <div id="myButtons" class="btn-group" data-toggle="buttons">
+                <label class="btn btn-primary active">
+                    <input id="ssh-key" type="radio" class="form-control"
+                           name="ssh-key" value="generate" checked> Generate a New SSH Key
+                </label>
+                <label class="btn btn-primary">
+                    <input id="ssh-key" type="radio" class="form-control"
+                           name="ssh-key" value="existing"> Use an Existing SSH Key
+                </label>
+            </div>
 
-            <label>Key Identity File Path</label>
-            <input id="identity-file" class="form-control"
-                   name="identity-file" required>
+            <br/>
+            <div id="existing-key" style="display: none">
+                <br/>
+                <label>Key Name</label>
+                <input id="key-name" class="form-control" name="key-name">
+
+                <label>Key Identity File Path</label>
+                <input id="identity-file" class="form-control"
+                       name="identity-file">
+            </div>
 
             <button class="btn btn-primary btn-block" type="submit">Add</button>
         </form>
     </div>
 </div>
+{% endblock %}
+
+{% block js %}
+<script type="text/javascript" language="javascript">
+    $("input:radio[name=ssh-key]").change(function() {
+        var value = $(this).val();
+
+        if (value == "existing") {
+            $("#existing-key").css("display", "inline");
+            $("#key-name").attr("required", "true");
+            $("#identity-file").attr("required", "true");
+        } else {
+            $("#existing-key").css("display", "none");
+            $("#key-name").removeAttr("required");
+            $("#identity-file").removeAttr("required");
+        }
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
- Display the status/result when submitting the form
- Validate the AWS key/secret entered by the user before saving
- Give the user an option to generate an EC2 ssh key from the script
- Ask for the user’s email address
- Provide feedback to the user if the operations were successful
- Validate that credentials path exists
- Tag the EC2 instances with the users email address
